### PR TITLE
Added a simple toggle, to display either as grid view or map view

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { AppBar, Box, IconButton, Stack, Toolbar } from '@mui/material';
 import Logo from '../Logo/Logo';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import ToggleView from '../ToggleView/ToggleView';
 
 function Header(){
     return(
@@ -13,6 +14,9 @@ function Header(){
                     ml: 2
                 }}>
                     <Logo expandOnHover />
+                </Box>
+                <Box>
+                    <ToggleView></ToggleView>
                 </Box>
                 <Stack direction={'row'} spacing={2}>
                     <IconButton>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,10 +15,8 @@ function Header(){
                 }}>
                     <Logo expandOnHover />
                 </Box>
-                <Box>
-                    <ToggleView></ToggleView>
-                </Box>
                 <Stack direction={'row'} spacing={2}>
+                    <ToggleView></ToggleView>
                     <IconButton>
                         <HelpOutlineIcon />
                     </IconButton>

--- a/src/components/ToggleView/ToggleView.tsx
+++ b/src/components/ToggleView/ToggleView.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import MapOutlinedIcon from '@mui/icons-material/MapOutlined';
+import ViewComfyOutlinedIcon from '@mui/icons-material/ViewComfyOutlined';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+
+export default function ToggleButtons() {
+  const [alignment, setAlignment] = React.useState<string | null>('left');
+
+  const handleAlignment = (
+    event: React.MouseEvent<HTMLElement>,
+    newAlignment: string | null,
+  ) => {
+    if (newAlignment !== null) {
+      setAlignment(newAlignment);
+    }
+  };
+
+  return (
+    <ToggleButtonGroup
+      value={alignment}
+      exclusive
+      onChange={handleAlignment}
+      aria-label="text alignment"
+    >
+      <ToggleButton value="left" aria-label="left aligned">
+        <ViewComfyOutlinedIcon />
+      </ToggleButton>
+      <ToggleButton value="right" aria-label="right aligned">
+        <MapOutlinedIcon />
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+}

--- a/src/components/ToggleView/ToggleView.tsx
+++ b/src/components/ToggleView/ToggleView.tsx
@@ -24,13 +24,13 @@ export default function ToggleButtons() {
       onChange={handleAlignment}
       aria-label="view mode"
     >
-      <ToggleButton value="left" aria-label="grid view">
+      <ToggleButton value="grid" aria-label="grid view">
         <Tooltip title='Grid'>
             <ViewComfyOutlinedIcon />
         </Tooltip>
       </ToggleButton>
 
-      <ToggleButton value="right" aria-label="map view">
+      <ToggleButton value="map" aria-label="map view">
         <Tooltip title='Map'>
             <MapOutlinedIcon />
         </Tooltip>

--- a/src/components/ToggleView/ToggleView.tsx
+++ b/src/components/ToggleView/ToggleView.tsx
@@ -21,12 +21,12 @@ export default function ToggleButtons() {
       value={alignment}
       exclusive
       onChange={handleAlignment}
-      aria-label="text alignment"
+      aria-label="view mode"
     >
-      <ToggleButton value="left" aria-label="left aligned">
+      <ToggleButton value="left" aria-label="grid view">
         <ViewComfyOutlinedIcon />
       </ToggleButton>
-      <ToggleButton value="right" aria-label="right aligned">
+      <ToggleButton value="right" aria-label="map view">
         <MapOutlinedIcon />
       </ToggleButton>
     </ToggleButtonGroup>

--- a/src/components/ToggleView/ToggleView.tsx
+++ b/src/components/ToggleView/ToggleView.tsx
@@ -3,6 +3,7 @@ import MapOutlinedIcon from '@mui/icons-material/MapOutlined';
 import ViewComfyOutlinedIcon from '@mui/icons-material/ViewComfyOutlined';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
 
 export default function ToggleButtons() {
   const [alignment, setAlignment] = React.useState<string | null>('left');
@@ -24,11 +25,17 @@ export default function ToggleButtons() {
       aria-label="view mode"
     >
       <ToggleButton value="left" aria-label="grid view">
-        <ViewComfyOutlinedIcon />
+        <Tooltip title='Grid'>
+            <ViewComfyOutlinedIcon />
+        </Tooltip>
       </ToggleButton>
+
       <ToggleButton value="right" aria-label="map view">
-        <MapOutlinedIcon />
+        <Tooltip title='Map'>
+            <MapOutlinedIcon />
+        </Tooltip>
       </ToggleButton>
+
     </ToggleButtonGroup>
   );
 }


### PR DESCRIPTION
This is purely cosmetic, and has no functionality yet.

Icons can be changed later.

![image](https://github.com/P3-Hype/SRAMS-frontend/assets/96435651/8a89e62a-2729-4e72-b970-6f26274e3581)
